### PR TITLE
Replace Eos with Fiveam

### DIFF
--- a/cl-rsvg2-test.asd
+++ b/cl-rsvg2-test.asd
@@ -18,4 +18,4 @@
   :serial t
   :components ((:static-file "tests/tux.svg")
                (:file "tests/rsvg-test"))
-  :depends-on (#:asdf #:cffi #:cl-rsvg2 #:eos))
+  :depends-on (#:asdf #:cffi #:cl-rsvg2 #:fiveam))

--- a/tests/rsvg-test.lisp
+++ b/tests/rsvg-test.lisp
@@ -1,6 +1,6 @@
 (defpackage #:cl-rsvg2-test
   (:nicknames #:rsvg2-test)
-  (:use #:cl #:cffi #:rsvg2 #:eos)
+  (:use #:cl #:cffi #:rsvg2 #:fiveam)
   (:export #:run!))
 
 (in-package #:cl-rsvg2-test)


### PR DESCRIPTION
Eos has been deprecated in favor of Fiveam